### PR TITLE
Тест TestCdwReader3() и вариант исправления ошибки по считыванию информации формата чертежа

### DIFF
--- a/KompasFileReader.Test/TestKompasFileReader.cs
+++ b/KompasFileReader.Test/TestKompasFileReader.cs
@@ -138,5 +138,41 @@ namespace KompasFileReader.Test
                 Assert.IsTrue(taskOpenCdwWithSpwFile.Result.IdStyle == 0, "CdwWithSpwAnalyzer has not result IdStyle incorrect");
             }
         }
+          //Тест для проверки считывания формата чертежа. 
+        //Если выпадет сообщение CdwWithSpwAnalyzer has not result, то тест совсем не пройден еще на этапе чтения файла.
+        //Если выпадет сообщение Format is null, то тест пройден наполовину (Формат чертежа не удается прочитать).
+    
+         [TestMethod]
+        public void TestCdwReader3()
+        {
+            const string path = @"\6013-AR.cdw";
+            var fullPath = StartupPath + path;
+            using (var inputStream = new FileStream(fullPath, FileMode.Open, FileAccess.Read))
+            {
+                var ms = new MemoryStream();
+                inputStream.Seek(0, SeekOrigin.Begin);
+                inputStream.CopyTo(ms);
+                ms.Position = 0;
+                var taskOpenCdwFile = new Task<CdwAnalyzer>(() => new CdwAnalyzer(ms));
+                taskOpenCdwFile.Start();
+                taskOpenCdwFile.Wait();
+                if (taskOpenCdwFile.Result.IsCompleted)
+                {
+                    var drawing = taskOpenCdwFile.Result.Drawing;
+                    foreach (KompasFileReader.Model.DrawingSheet ee in taskOpenCdwFile.Result.Drawing.Sheets)
+                    {
+                        if (ee != null)
+                        {
+                           string FormatTxt = ee.Format;
+                            Assert.IsTrue(ee.Format != null, "Format is null");
+                        }
+                    }
+                }
+                else
+                {
+                    Assert.Fail("CdwWithSpwAnalyzer has not result");
+                }
+            }
+        }
     }
 }

--- a/KompasFileReader/Analyzer/CdwAnalyzer.cs
+++ b/KompasFileReader/Analyzer/CdwAnalyzer.cs
@@ -82,6 +82,9 @@ namespace KompasFileReader.Analyzer
             foreach (var sheet in sheets)
             {
                 var ds = new DrawingSheet();
+                  // Возможная ошибка в строке  foreach (var attr in sheet.Attributes()). 
+                //Внутрь цикла попасть не можем потому что мы не учли, что тип xml узла может быть не только XElement, но и XComment.
+                /*
                 foreach (var attr in sheet.Attributes())
                 {
                     string strnum;
@@ -106,6 +109,38 @@ namespace KompasFileReader.Analyzer
                     strnum = attr.Value;
                     if (int.TryParse(strnum, out number))
                         ds.Width = number;
+                }*/
+                // Код исправляющий ошибку:
+                  foreach (XNode attrs in sheet.Nodes())
+                {
+                    XElement elm = attrs as XElement;
+                    
+                    if (elm != null)
+                    {
+                        string strnum;
+                        int number;
+                        foreach (XAttribute attr in elm.Attributes())
+                        {
+                            if (attr.Name == "format")
+                                ds.Format = attr.Value;
+                            if (attr.Name == "orientation")
+                            {
+                                strnum = attr.Value;
+                                if (int.TryParse(strnum, out number))
+                                    ds.Orientation = number;
+                            }
+                            if (attr.Name == "height")
+                            {
+                                strnum = attr.Value;
+                                if (int.TryParse(strnum, out number))
+                                    ds.Height = number;
+                            }
+                            if (attr.Name != "width") continue;
+                            strnum = attr.Value;
+                            if (int.TryParse(strnum, out number))
+                                ds.Width = number;
+                        }
+                    }
                 }
                 Drawing.Sheets.Add(ds);
             }


### PR DESCRIPTION
По моим наблюдениям ошибка кроется в файле CdwAnalyzer.cs в строке foreach (var attr in sheet.Attributes())
 Внутрь цикла попасть не можем.
Предлагаю заменить на:
 foreach (XNode attrs in sheet.Nodes())
                {
                    XElement elm = attrs as XElement;
                    if (elm != null)
                    {
                        string strnum;
                        int number;
                        foreach (XAttribute attr in elm.Attributes())
                        {..........}
                  }
            }